### PR TITLE
Version 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # MinorJS Changelog
 
-## Version 5.1.2, March 26th, 2020
+## Version 6.0.0, March 31th, 2020
 
-* chore: changed template loader from haml to pug
+* breaking: changed default template loader from haml to pug
 
 ## Version 5.1.1, April 5th, 2018
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "copyright": "Copyright 2016 Skytap Inc. Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at     http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.",
   "name": "minorjs",
-  "version": "5.1.2",
+  "version": "6.0.0",
   "description": "Clustered web framework that favors convention over configuration.",
   "author": {
     "name": "Skytap",


### PR DESCRIPTION
bump minorjs to version 6.0.0 since we changed the default template to pug