### PR TITLE
Update express version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # MinorJS Changelog
 
+## Version 7.0.2 December 7th, 2022
+* chore: update express version to ~4.18.0 to remediate CVE
+
 ## Version 7.0.1, June 24, 2021
 
 * chore: update minorjs-test version and upgrade underscore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # MinorJS Changelog
 
-## Version 7.0.2 December 7th, 2022
+## Version 7.0.2 December 21st, 2022
 * chore: update express version to ~4.18.0 to remediate CVE
+* chore: update body parser version to ~1.19.0 to remediate CVE
 
 ## Version 7.0.1, June 24, 2021
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "consolidate": "^0.15.1",
     "cookie-parser": "~1.4.0",
     "errorhandler": "~1.4.2",
-    "express": "~4.16.3",
+    "express": "~4.18.0",
     "extend": "~3.0.0",
     "humanize-plus": "~1.8.2",
     "inflected": "~1.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "copyright": "Copyright 2016 Skytap Inc. Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at     http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.",
   "name": "minorjs",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Clustered web framework that favors convention over configuration.",
   "author": {
     "name": "Skytap",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "backhoe": "~0.0.3",
     "bluebird": "~3.0.6",
-    "body-parser": "~1.18.2",
+    "body-parser": "~1.19.0",
     "compression": "~1.7.2",
     "consolidate": "^0.15.1",
     "cookie-parser": "~1.4.0",


### PR DESCRIPTION
Update express and body-parser versions to address CVE.
[Reference for updating Skytap-owned npm modules](https://confluence.corp.skytap.com/display/FRON/Updating+modules+to+address+CVEs) <-- followed this process