### PR TITLE
CVE-2025-7339 Fix  on-headers is vulnerable to http response header manipulation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # MinorJS Changelog
 
+## Version 7.0.4 Aug 14th, 2025
+* chore: update compression version to ~1.8.1 to remediate CVE
+
 ## Version 7.0.3 April 4th, 2024
 * chore: update express version to ~4.19.2 to remediate CVE
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "backhoe": "~0.0.3",
     "bluebird": "~3.0.6",
     "body-parser": "~1.19.0",
-    "compression": "~1.7.2",
+    "compression": "~1.8.1",
     "consolidate": "^0.15.1",
     "cookie-parser": "~1.4.0",
     "errorhandler": "~1.4.2",
@@ -59,8 +59,8 @@
     "wrench": "~1.5.8"
   },
   "devDependencies": {
-    "coffeescript": "~1.10.0",
     "cheerio": "~0.20.0",
+    "coffeescript": "~1.10.0",
     "grunt": "~1.0.1",
     "grunt-cli": "~1.2.0",
     "grunt-mocha-test": "~0.12.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "copyright": "Copyright 2016 Skytap Inc. Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at     http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.",
   "name": "minorjs",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "Clustered web framework that favors convention over configuration.",
   "author": {
     "name": "Skytap",


### PR DESCRIPTION
### CVE 2025 7339 Fix  on-headers is vulnerable to http response header manipulation 

As  described in the title, this is an attempt to fix CVE-2025-7339.